### PR TITLE
fix pip conflicts

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-numpy==1.22.4
+numpy==1.22.1
 pandas-gbq==0.17.4
 psycopg2==2.9.3
 pybigquery==0.5.0
-apache-superset==1.5.0
+apache-superset==2.0.0
 markupsafe==2.0.1


### PR DESCRIPTION
When I was trying to create the Dev Container for this repo, the build process stopped in the pip install requirements part. That happened because of pip conflicts, which I solved with the PR configuration. Also, the superset used in `./src/Dockerfile` is the 2.0.0 version, hence the change in the Superset pip package.